### PR TITLE
Rename DRO risk measure to ModifiedChiSquared

### DIFF
--- a/src/plugins/risk_measures.jl
+++ b/src/plugins/risk_measures.jl
@@ -171,7 +171,7 @@ function EAVaR(;lambda::Float64=1.0, beta::Float64=1.0)
     return lambda * Expectation() + (1 - lambda) * AVaR(beta)
 end
 
-# ===================================== DRO ================================== #
+# ================================= Modified-Χ² ============================== #
 
 #=
 This code was contributed by Lea Kapelevich.
@@ -201,18 +201,18 @@ Note: the largest radius that will work with S scenarios is sqrt((S-1)/S).
 =#
 
 """
-    DRO(radius::Float64)
+    ModifiedChiSquared(radius::Float64)
 
 The distributionally robust SDDP risk measure of
 
 Philpott, A., de Matos, V., Kapelevich, L. Distributionally robust SDDP.
 Computational Management Science (2018) 165:431-454.
 """
-struct DRO <: AbstractRiskMeasure
+struct ModifiedChiSquared <: AbstractRiskMeasure
     radius::Float64
 end
 
-function adjust_probability(measure::DRO,
+function adjust_probability(measure::ModifiedChiSquared,
                             risk_adjusted_probability::Vector{Float64},
                             original_probability::Vector{Float64},
                             noise_support::Vector,
@@ -220,8 +220,8 @@ function adjust_probability(measure::DRO,
                             is_minimization::Bool)
     if abs(measure.radius) < 1e-9 ||
             Statistics.std(objective_realizations, corrected=false) < 1e-9
-        # Don't do any DRO reweighting if the radius is small or the variance
-        # is too low. Use Expectation instead.
+        # Don't do any reweighting if the radius is small or the variance is too
+        # low. Use Expectation instead.
         return adjust_probability(
            Expectation(), risk_adjusted_probability, original_probability,
            noise_support, objective_realizations, is_minimization)
@@ -242,13 +242,13 @@ Algorithm (1) of Philpott et al. Assumes that the nominal distribution is _not_
 uniform.
 """
 function non_uniform_dro(
-        measure::DRO,
+        measure::ModifiedChiSquared,
         risk_adjusted_probability::Vector{Float64},
         original_probability::Vector{Float64},
         objective_realizations::Vector{Float64},
         is_minimization::Bool)
-    error("Current implementation of DRO assumes that the nominal " *
-          "distribution is uniform.")
+    error("Current implementation of ModifiedChiSquared assumes that the " *
+          "nominal distribution is uniform.")
 end
 
 """
@@ -256,7 +256,7 @@ Algorithm (2) of Philpott et al. Assumes that the nominal distribution is
 uniform.
 """
 function uniform_dro(
-        measure::DRO,
+        measure::ModifiedChiSquared,
         risk_adjusted_probability::Vector{Float64},
         original_probability::Vector{Float64},
         objective_realizations::Vector{Float64},

--- a/test/plugins/risk_measures.jl
+++ b/test/plugins/risk_measures.jl
@@ -162,11 +162,11 @@ end
     end
 end
 
-@testset "DRO" begin
+@testset "ModifiedChiSquared" begin
     @testset "Min - R=0.25" begin
         risk_adjusted_probability = Vector{Float64}(undef, 5)
         Kokako.adjust_probability(
-            Kokako.DRO(0.25),
+            Kokako.ModifiedChiSquared(0.25),
             risk_adjusted_probability,
             fill(0.2, 5),
             [:a, :b, :c, :d, :e],
@@ -178,7 +178,7 @@ end
     @testset "Max - R=0.25" begin
         risk_adjusted_probability = Vector{Float64}(undef, 5)
         Kokako.adjust_probability(
-            Kokako.DRO(0.25),
+            Kokako.ModifiedChiSquared(0.25),
             risk_adjusted_probability,
             fill(0.2, 5),
             [:a, :b, :c, :d, :e],
@@ -190,7 +190,7 @@ end
     @testset "Min - R=0.4" begin
         risk_adjusted_probability = Vector{Float64}(undef, 5)
         Kokako.adjust_probability(
-            Kokako.DRO(0.4),
+            Kokako.ModifiedChiSquared(0.4),
             risk_adjusted_probability,
             fill(0.2, 5),
             [:a, :b, :c, :d, :e],
@@ -202,7 +202,7 @@ end
     @testset "Max - R=0.4" begin
         risk_adjusted_probability = Vector{Float64}(undef, 5)
         Kokako.adjust_probability(
-            Kokako.DRO(0.4),
+            Kokako.ModifiedChiSquared(0.4),
             risk_adjusted_probability,
             fill(0.2, 5),
             [:a, :b, :c, :d, :e],
@@ -214,7 +214,7 @@ end
     @testset "Min - R=√0.8" begin
         risk_adjusted_probability = Vector{Float64}(undef, 5)
         Kokako.adjust_probability(
-            Kokako.DRO(sqrt(0.8)),
+            Kokako.ModifiedChiSquared(sqrt(0.8)),
             risk_adjusted_probability,
             fill(0.2, 5),
             [:a, :b, :c, :d, :e],


### PR DESCRIPTION
Since we now have a Wasserstein as well, it seems mean to steal the "DRO" name.

cc @lkapelevich